### PR TITLE
Fix GitHub URLs in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,10 +11,10 @@
         "Jonathan Scott Duff <duff@pobox.com> [deceased]"
     ],
     "support"     : {
-        "bugtracker" : "https://github.com/tbrowder/Math-Trig-Raku/issues"
+        "bugtracker" : "https://github.com/tbrowder/Math-Trig/issues"
     },
     "repo-type": "git",
-    "source-url" : "https:://github.com/tbrowder/Math-Trig-Raku.git",
+    "source-url" : "https://github.com/tbrowder/Math-Trig.git",
     "depends" : [ ],
     "build-depends" : [ ],
     "test-depends" : [


### PR DESCRIPTION
Drop the old "-Raku" suffix and the erroneous second colon on the protocol.